### PR TITLE
Replaced client.service_instance._get_token() with client.token

### DIFF
--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Chroma to create a pattern about IBM.ipynb
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Chroma to create a pattern about IBM.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U 'ibm-watsonx-ai[rag]>=1.1.11' | tail -n 1\n",
+    "!pip install -U 'ibm-watsonx-ai[rag]>=1.2.4' | tail -n 1\n",
     "!pip install -U \"langchain_community>=0.3,<0.4\" | tail -n 1"
    ]
   },
@@ -343,7 +343,7 @@
     "    retrieval_methods=[\"simple\"],\n",
     "    chunking=[\n",
     "        {\n",
-    "            \"chunk_size\": 512, \n",
+    "            \"chunk_size\": 512,\n",
     "            \"chunk_overlap\": 64,\n",
     "            \"method\": \"recursive\"\n",
     "        }\n",
@@ -1173,7 +1173,7 @@
     "    client.deployments.ScoringMetaNames.INPUT_DATA: [\n",
     "        {\n",
     "            \"values\": questions,\n",
-    "            \"access_token\": client.service_instance._get_token()\n",
+    "            \"access_token\": client.token\n",
     "        }\n",
     "    ]\n",
     "}\n",
@@ -1595,7 +1595,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "watsonx-ai-rt23.1-py310-osx64",
+   "display_name": "watson-machine-learning-samples",
    "language": "python",
    "name": "python3"
   },
@@ -1609,7 +1609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Milvus to create a pattern about IBM.ipynb
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Milvus to create a pattern about IBM.ipynb
@@ -70,7 +70,7 @@
       "outputs": [],
       "source": [
         "!pip install -U wget | tail -n 1\n",
-        "!pip install -U 'ibm-watsonx-ai[rag]>=1.1.11' | tail -n 1"
+        "!pip install -U 'ibm-watsonx-ai[rag]>=1.2.4' | tail -n 1"
       ]
     },
     {
@@ -176,7 +176,7 @@
         "filename = \"watsonx-ai-python-sdk\"\n",
         "filename_zip = \"watsonx-ai-python-sdk.zip\"\n",
         "\n",
-        "if not os.path.isfile(filename_zip): \n",
+        "if not os.path.isfile(filename_zip):\n",
         "    wget.download(\"https://github.com/IBM/watsonx-ai-python-sdk/archive/refs/heads/gh-pages.zip\", out=filename_zip)\n",
         "\n",
         "with zipfile.ZipFile(filename_zip, \"r\") as zip_ref:\n",
@@ -244,7 +244,7 @@
         "\n",
         "for ind, html_docs_file in enumerate(html_docs_files):\n",
         "    container_data_connection.write(html_docs_file, remote_name = html_docs_file.split(\"/\")[-1])\n",
-        "    \n",
+        "\n",
         "    sys.stdout.write(f\"\\rProgress: {'✓' * (ind+1)}{'.' * (len(html_docs_files)-ind-1)}\\r\")\n",
         "    sys.stdout.flush()"
       ]
@@ -941,7 +941,7 @@
         "    client.deployments.ScoringMetaNames.INPUT_DATA: [\n",
         "        {\n",
         "            \"values\": questions,\n",
-        "            \"access_token\": client.service_instance._get_token()\n",
+        "            \"access_token\": client.token\n",
         "        }\n",
         "    ]\n",
         "}\n",

--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG with watsonx Text Extraction service.ipynb
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG with watsonx Text Extraction service.ipynb
@@ -1,38 +1,18 @@
 {
- "metadata": {
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.11",
-   "language": "python"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11.9",
-   "mimetype": "text/x-python",
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "pygments_lexer": "ipython3",
-   "nbconvert_exporter": "python",
-   "file_extension": ".py"
-  }
- },
- "nbformat_minor": 5,
- "nbformat": 4,
  "cells": [
   {
-   "id": "2373ada319e4fda5",
    "cell_type": "markdown",
+   "id": "2373ada319e4fda5",
+   "metadata": {},
    "source": [
     "![image](https://raw.githubusercontent.com/IBM/watson-machine-learning-samples/master/cloud/notebooks/headers/watsonx-Prompt_Lab-Notebook.png)\n",
     "# Use AutoAI RAG with watsonx Text Extraction service"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "24aa5fa58bb5d946",
    "cell_type": "markdown",
+   "id": "24aa5fa58bb5d946",
+   "metadata": {},
    "source": [
     "#### Disclaimers\n",
     "\n",
@@ -65,12 +45,12 @@
     "- [Run the AutoAI RAG experiment](#run-autorag)\n",
     "- [Compare and test RAG Patterns](#comparision)\n",
     "- [Summary](#summary)"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "797be889df452a0c",
    "cell_type": "markdown",
+   "id": "797be889df452a0c",
+   "metadata": {},
    "source": [
     "<a id=\"setup\"></a>\n",
     "# Set up the environment\n",
@@ -78,45 +58,49 @@
     "Before you use the sample code in this notebook, you must perform the following setup tasks:\n",
     "\n",
     "-  Create a <a href=\"https://cloud.ibm.com/catalog/services/watson-machine-learning\" target=\"_blank\" rel=\"noopener no referrer\">watsonx.ai Runtime Service</a> instance (a free plan is offered and information about how to create the instance can be found <a href=\"https://dataplatform.cloud.ibm.com/docs/content/wsj/getting-started/wml-plans.html?context=wx&audience=wdp\" target=\"_blank\" rel=\"noopener no referrer\">here</a>)."
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "markdown",
    "id": "77e9a79e53ca99e9",
-   "cell_type": "markdown",
-   "source": "### Install and import the required modules and dependencies",
-   "metadata": {}
-  },
-  {
    "metadata": {},
-   "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
-    "!pip install -U 'ibm-watsonx-ai[rag]>=1.1.24' | tail -n 1\n",
-    "!pip install -U \"langchain_community>=0.3,<0.4\" | tail -n 1"
-   ],
-   "id": "dd46247ca5490688"
+    "### Install and import the required modules and dependencies"
+   ]
   },
   {
-   "id": "e5a79fd5b0a8d2e6",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd46247ca5490688",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U 'ibm-watsonx-ai[rag]>=1.2.4' | tail -n 1\n",
+    "!pip install -U \"langchain_community>=0.3,<0.4\" | tail -n 1"
+   ]
+  },
+  {
    "cell_type": "markdown",
+   "id": "e5a79fd5b0a8d2e6",
+   "metadata": {},
    "source": [
     "### Define the watsonx.ai credentials\n",
     "This cell defines the credentials required to work with the watsonx.ai service.\n",
     "\n",
     "**Action:** Provide your IBM Cloud API key and the platform URL. For more information, see <a href=\"https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui\" target=\"_blank\" rel=\"noopener no referrer\">Managing user API keys</a>."
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "871e4d4831dfff81",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:17:03.432461Z",
      "start_time": "2025-01-09T15:17:03.430046Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "import getpass\n",
     "\n",
@@ -126,14 +110,12 @@
     "    url=\"https://us-south.ml.cloud.ibm.com\",\n",
     "    api_key=getpass.getpass(\"Please enter your watsonx.ai api key (hit enter): \")\n",
     ")"
-   ],
-   "id": "871e4d4831dfff81",
-   "outputs": [],
-   "execution_count": 22
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "a7d9204ae2b4503d",
+   "metadata": {},
    "source": [
     "### Work with spaces\n",
     "\n",
@@ -149,113 +131,135 @@
     "**Tip**: You can also use SDK to prepare the space for your work. For more information, see [the Space management notebook](https://github.com/IBM/watson-machine-learning-samples/blob/master/cloud/notebooks/python_sdk/instance-management/Space%20management.ipynb).\n",
     "\n",
     "**Action**: Assign space ID below."
-   ],
-   "id": "a7d9204ae2b4503d"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "edfc7a406063d875",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:17:23.482166Z",
      "start_time": "2025-01-09T15:17:23.480080Z"
     }
    },
-   "cell_type": "code",
-   "source": "SPACE_ID = 'PASTE YOUR SPACE GUID HERE'",
-   "id": "edfc7a406063d875",
    "outputs": [],
-   "execution_count": 24
+   "source": [
+    "SPACE_ID = 'PASTE YOUR SPACE GUID HERE'"
+   ]
   },
   {
-   "id": "a0c9b2035ae5e023",
    "cell_type": "markdown",
-   "source": "### Create an instance of APIClient with authentication details",
-   "metadata": {}
+   "id": "a0c9b2035ae5e023",
+   "metadata": {},
+   "source": [
+    "### Create an instance of APIClient with authentication details"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6191de9d36b0ea37",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:17:34.654925Z",
      "start_time": "2025-01-09T15:17:32.854580Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "from ibm_watsonx_ai import APIClient\n",
     "\n",
     "client = APIClient(credentials=credentials, space_id=SPACE_ID)"
-   ],
-   "id": "6191de9d36b0ea37",
-   "outputs": [],
-   "execution_count": 25
+   ]
   },
   {
+   "cell_type": "markdown",
    "id": "1a538feb8038c56b",
-   "cell_type": "markdown",
-   "source": "### Create an instance of COS client",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### Create an instance of COS client"
+   ]
   },
   {
+   "cell_type": "markdown",
    "id": "b292e1bcfbd5849a",
-   "cell_type": "markdown",
-   "source": "Connect to the default COS instance for the provided space by using the `ibm_boto3` package.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "Connect to the default COS instance for the provided space by using the `ibm_boto3` package."
+   ]
   },
   {
-   "id": "1df2d93b579cdd34",
    "cell_type": "code",
-   "source": "import ibm_boto3\n\ncos_credentials = client.spaces.get_details(space_id=SPACE_ID)['entity']['storage']['properties']\n\ncos_client = ibm_boto3.client(\n    service_name=\"s3\",\n    endpoint_url=cos_credentials[\"endpoint_url\"],\n    aws_access_key_id=cos_credentials[\"credentials\"][\"editor\"][\"access_key_id\"],\n    aws_secret_access_key=cos_credentials[\"credentials\"][\"editor\"][\"secret_access_key\"],\n)",
+   "execution_count": 26,
+   "id": "1df2d93b579cdd34",
    "metadata": {
-    "id": "3f8b9e40-985e-44cf-a1d6-509493ea85bc",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:17:50.947335Z",
      "start_time": "2025-01-09T15:17:49.986337Z"
-    }
+    },
+    "id": "3f8b9e40-985e-44cf-a1d6-509493ea85bc"
    },
    "outputs": [],
-   "execution_count": 26
+   "source": [
+    "import ibm_boto3\n",
+    "\n",
+    "cos_credentials = client.spaces.get_details(space_id=SPACE_ID)['entity']['storage']['properties']\n",
+    "\n",
+    "cos_client = ibm_boto3.client(\n",
+    "    service_name=\"s3\",\n",
+    "    endpoint_url=cos_credentials[\"endpoint_url\"],\n",
+    "    aws_access_key_id=cos_credentials[\"credentials\"][\"editor\"][\"access_key_id\"],\n",
+    "    aws_secret_access_key=cos_credentials[\"credentials\"][\"editor\"][\"secret_access_key\"],\n",
+    ")"
+   ]
   },
   {
-   "id": "fb7353b94e404e69",
    "cell_type": "markdown",
-   "source": "Create a new bucket.",
-   "metadata": {}
+   "id": "fb7353b94e404e69",
+   "metadata": {},
+   "source": [
+    "Create a new bucket."
+   ]
   },
   {
-   "id": "705245bc2f2785d6",
    "cell_type": "code",
+   "execution_count": 27,
+   "id": "705245bc2f2785d6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-09T15:17:53.625465Z",
+     "start_time": "2025-01-09T15:17:52.147218Z"
+    },
+    "id": "0b34af2a-04ab-497f-ab91-ee764a0df804"
+   },
+   "outputs": [],
    "source": [
     "cos_bucket_name = \"autoai-rag-with-text-extraction-experiment\"\n",
     "\n",
     "buckets_names = [bucket[\"Name\"] for bucket in cos_client.list_buckets()[\"Buckets\"]]\n",
     "if not cos_bucket_name in buckets_names:\n",
     "    cos_client.create_bucket(Bucket=cos_bucket_name)"
-   ],
-   "metadata": {
-    "id": "0b34af2a-04ab-497f-ab91-ee764a0df804",
-    "ExecuteTime": {
-     "end_time": "2025-01-09T15:17:53.625465Z",
-     "start_time": "2025-01-09T15:17:52.147218Z"
-    }
-   },
-   "outputs": [],
-   "execution_count": 27
+   ]
   },
   {
-   "id": "afa211d65c3f216",
    "cell_type": "markdown",
-   "source": "Initialize the client connection to the created bucket and get the connection ID.",
-   "metadata": {}
+   "id": "afa211d65c3f216",
+   "metadata": {},
+   "source": [
+    "Initialize the client connection to the created bucket and get the connection ID."
+   ]
   },
   {
-   "id": "17b0d8d77c8a04f8",
    "cell_type": "code",
-   "source": "connection_details = client.connections.create(\n    {\n        \"datasource_type\": client.connections.get_datasource_type_uid_by_name(\n            \"bluemixcloudobjectstorage\"\n        ),\n        \"name\": \"Connection to COS for tests\",\n        \"properties\": {\n            \"bucket\": cos_bucket_name,\n            \"access_key\": cos_credentials[\"credentials\"][\"editor\"][\"access_key_id\"],\n            \"secret_key\": cos_credentials[\"credentials\"][\"editor\"][\"secret_access_key\"],\n            \"iam_url\": client.service_instance._href_definitions.get_iam_token_url(),\n            \"url\": cos_credentials[\"endpoint_url\"],\n        },\n    }\n)\n\ncos_connection_id = client.connections.get_id(\n    connection_details\n)",
+   "execution_count": 28,
+   "id": "17b0d8d77c8a04f8",
    "metadata": {
-    "id": "2d2233f0-4717-4aef-b2b0-ed63afdc19c1",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:01.575234Z",
      "start_time": "2025-01-09T15:17:53.631336Z"
-    }
+    },
+    "id": "2d2233f0-4717-4aef-b2b0-ed63afdc19c1"
    },
    "outputs": [
     {
@@ -267,22 +271,51 @@
      ]
     }
    ],
-   "execution_count": 28
+   "source": [
+    "connection_details = client.connections.create(\n",
+    "    {\n",
+    "        \"datasource_type\": client.connections.get_datasource_type_uid_by_name(\n",
+    "            \"bluemixcloudobjectstorage\"\n",
+    "        ),\n",
+    "        \"name\": \"Connection to COS for tests\",\n",
+    "        \"properties\": {\n",
+    "            \"bucket\": cos_bucket_name,\n",
+    "            \"access_key\": cos_credentials[\"credentials\"][\"editor\"][\"access_key_id\"],\n",
+    "            \"secret_key\": cos_credentials[\"credentials\"][\"editor\"][\"secret_access_key\"],\n",
+    "            \"iam_url\": client.service_instance._href_definitions.get_iam_token_url(),\n",
+    "            \"url\": cos_credentials[\"endpoint_url\"],\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "cos_connection_id = client.connections.get_id(\n",
+    "    connection_details\n",
+    ")"
+   ]
   },
   {
-   "id": "ff0a7b3c2e49edb0",
    "cell_type": "markdown",
+   "id": "ff0a7b3c2e49edb0",
+   "metadata": {},
    "source": [
     "<a id=\"prepare-te\"></a>\n",
     "## Prepare data and connections for the Text Extraction service\n",
     "\n",
     "The document, from which we are going to extract text, is located in the IBM Cloud Object Storage (COS). In this notebook, we will use the [Granite Code Models paper](https://arxiv.org/pdf/2405.04324) as a source text document. The final results file, which will contain extracted text and necessary metadata, will be placed in the COS. So we will use the `ibm_watsonx_ai.helpers.DataConnection` and the `ibm_watsonx_ai.helpers.S3Location` class to create Python objects that will represent the references to the processed files. Reference to the final results will be used as an input for the AutoAI RAG experiment. "
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "6986db8afa2092a0",
    "cell_type": "code",
+   "execution_count": 29,
+   "id": "6986db8afa2092a0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-09T15:18:01.583626Z",
+     "start_time": "2025-01-09T15:18:01.581803Z"
+    },
+    "id": "dbfed6f2-ff47-4ddf-a95b-2a997bb878a0"
+   },
+   "outputs": [],
    "source": [
     "from ibm_watsonx_ai.helpers import DataConnection, S3Location\n",
     "\n",
@@ -290,38 +323,26 @@
     "\n",
     "te_input_filename = \"granite_code_models_paper.pdf\"\n",
     "te_result_filename = \"granite_code_models_paper.md\""
-   ],
-   "metadata": {
-    "id": "dbfed6f2-ff47-4ddf-a95b-2a997bb878a0",
-    "ExecuteTime": {
-     "end_time": "2025-01-09T15:18:01.583626Z",
-     "start_time": "2025-01-09T15:18:01.581803Z"
-    }
-   },
-   "outputs": [],
-   "execution_count": 29
+   ]
   },
   {
-   "id": "f69a91d41da6d94d",
    "cell_type": "markdown",
-   "source": "Download and upload training data to the COS bucket. Then define a connection to the uploaded file.",
-   "metadata": {}
+   "id": "f69a91d41da6d94d",
+   "metadata": {},
+   "source": [
+    "Download and upload training data to the COS bucket. Then define a connection to the uploaded file."
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4d2e0021b4ccfae3",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:02.313079Z",
      "start_time": "2025-01-09T15:18:01.595337Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "import wget\n",
-    "\n",
-    "wget.download(data_url, te_input_filename)\n",
-    "cos_client.upload_file(te_input_filename, cos_bucket_name, te_input_filename)"
-   ],
-   "id": "4d2e0021b4ccfae3",
    "outputs": [
     {
      "data": {
@@ -334,135 +355,166 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 30
+   "source": [
+    "import wget\n",
+    "\n",
+    "wget.download(data_url, te_input_filename)\n",
+    "cos_client.upload_file(te_input_filename, cos_bucket_name, te_input_filename)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Input file connection.",
-   "id": "61322fcdd5148ca5"
+   "id": "61322fcdd5148ca5",
+   "metadata": {},
+   "source": [
+    "Input file connection."
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "457123d62baee219",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:03.939674Z",
      "start_time": "2025-01-09T15:18:02.385866Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "input_data_reference = DataConnection(\n",
     "    connection_asset_id=cos_connection_id,\n",
     "    location=S3Location(bucket=cos_bucket_name, path=te_input_filename),\n",
     ")\n",
     "input_data_reference.set_client(client)"
-   ],
-   "id": "457123d62baee219",
-   "outputs": [],
-   "execution_count": 31
+   ]
   },
   {
-   "id": "ef0a2d3adef6dbe6",
    "cell_type": "markdown",
-   "source": "Output file connection.",
-   "metadata": {}
+   "id": "ef0a2d3adef6dbe6",
+   "metadata": {},
+   "source": [
+    "Output file connection."
+   ]
   },
   {
-   "id": "93d11d2581f5d8e6",
    "cell_type": "code",
-   "source": "result_data_reference = DataConnection(\n    connection_asset_id=cos_connection_id, \n    location=S3Location(\n        bucket=cos_bucket_name,\n        path=te_result_filename\n    )\n)\nresult_data_reference.set_client(client)",
+   "execution_count": 32,
+   "id": "93d11d2581f5d8e6",
    "metadata": {
-    "id": "81c72273-05aa-4f62-92ae-2ed011072e65",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:10.145056Z",
      "start_time": "2025-01-09T15:18:10.142493Z"
-    }
+    },
+    "id": "81c72273-05aa-4f62-92ae-2ed011072e65"
    },
    "outputs": [],
-   "execution_count": 32
+   "source": [
+    "result_data_reference = DataConnection(\n",
+    "    connection_asset_id=cos_connection_id,\n",
+    "    location=S3Location(\n",
+    "        bucket=cos_bucket_name,\n",
+    "        path=te_result_filename\n",
+    "    )\n",
+    ")\n",
+    "result_data_reference.set_client(client)"
+   ]
   },
   {
-   "id": "9770cd3738d64e83",
    "cell_type": "markdown",
+   "id": "9770cd3738d64e83",
+   "metadata": {},
    "source": [
     "<a id=\"run-te\"></a>\n",
     "## Process data using the Text Extraction service"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "629b6e92699ab5f7",
    "cell_type": "markdown",
-   "source": "Initialize the Text Extraction service endpoint.",
-   "metadata": {}
+   "id": "629b6e92699ab5f7",
+   "metadata": {},
+   "source": [
+    "Initialize the Text Extraction service endpoint."
+   ]
   },
   {
-   "id": "ec363d7dd83678fe",
    "cell_type": "code",
-   "source": "from ibm_watsonx_ai.foundation_models.extractions import TextExtractions\n\nextraction = TextExtractions(\n    credentials=credentials,\n    space_id=SPACE_ID,\n)",
+   "execution_count": 33,
+   "id": "ec363d7dd83678fe",
    "metadata": {
-    "id": "fbacb600-3fac-4360-a73b-acd3a22e4dc9",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:13.718252Z",
      "start_time": "2025-01-09T15:18:12.370183Z"
-    }
+    },
+    "id": "fbacb600-3fac-4360-a73b-acd3a22e4dc9"
    },
    "outputs": [],
-   "execution_count": 33
+   "source": [
+    "from ibm_watsonx_ai.foundation_models.extractions import TextExtractions\n",
+    "\n",
+    "extraction = TextExtractions(\n",
+    "    credentials=credentials,\n",
+    "    space_id=SPACE_ID,\n",
+    ")"
+   ]
   },
   {
-   "id": "3ee3d5c200c3b3dd",
    "cell_type": "markdown",
-   "source": "Run a text extraction job for connections created in the previous step.",
-   "metadata": {}
+   "id": "3ee3d5c200c3b3dd",
+   "metadata": {},
+   "source": [
+    "Run a text extraction job for connections created in the previous step."
+   ]
   },
   {
-   "id": "dcc836b68a2db40a",
    "cell_type": "code",
-   "source": "from ibm_watsonx_ai.metanames import TextExtractionsMetaNames\n\nresponse = extraction.run_job(\n    document_reference=input_data_reference,\n    results_reference=result_data_reference,\n    steps={\n        TextExtractionsMetaNames.OCR: {\n            \"process_image\": True,\n            \"languages_list\": [\"en\"],\n        },\n        TextExtractionsMetaNames.TABLE_PROCESSING: {\"enabled\": True},\n    },\n    results_format=\"markdown\",\n)\n\njob_id = response['metadata']['id']",
+   "execution_count": 34,
+   "id": "dcc836b68a2db40a",
    "metadata": {
-    "id": "10c0ebab-37b0-4eea-b0e8-8be7f09f774a",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:15.347001Z",
      "start_time": "2025-01-09T15:18:14.364135Z"
-    }
+    },
+    "id": "10c0ebab-37b0-4eea-b0e8-8be7f09f774a"
    },
    "outputs": [],
-   "execution_count": 34
-  },
-  {
-   "id": "ca63ff5343081559",
-   "cell_type": "markdown",
-   "source": "Wait for the job to be complete.",
-   "metadata": {}
-  },
-  {
-   "id": "9a933380bd5cfc36",
-   "cell_type": "code",
    "source": [
-    "import json\n",
-    "import time\n",
+    "from ibm_watsonx_ai.metanames import TextExtractionsMetaNames\n",
     "\n",
-    "while True:\n",
-    "    job_details = extraction.get_job_details(job_id)\n",
-    "    status = job_details['entity']['results']['status']\n",
-    "    \n",
-    "    if status == \"completed\":\n",
-    "        print(\"Job completed successfully, details: {}\".format(json.dumps(job_details, indent=2)))\n",
-    "        break\n",
-    "    \n",
-    "    if status == \"failed\":\n",
-    "        print(\"Job failed, details: {}. \\n Try to run job again.\".format(json.dumps(job_details, indent=2)))\n",
-    "        break\n",
+    "response = extraction.run_job(\n",
+    "    document_reference=input_data_reference,\n",
+    "    results_reference=result_data_reference,\n",
+    "    steps={\n",
+    "        TextExtractionsMetaNames.OCR: {\n",
+    "            \"process_image\": True,\n",
+    "            \"languages_list\": [\"en\"],\n",
+    "        },\n",
+    "        TextExtractionsMetaNames.TABLE_PROCESSING: {\"enabled\": True},\n",
+    "    },\n",
+    "    results_format=\"markdown\",\n",
+    ")\n",
     "\n",
-    "    time.sleep(10)"
-   ],
+    "job_id = response['metadata']['id']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca63ff5343081559",
+   "metadata": {},
+   "source": [
+    "Wait for the job to be complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "9a933380bd5cfc36",
    "metadata": {
-    "id": "1ec0a420-d284-4577-8d55-8b11831f997d",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:48.549914Z",
      "start_time": "2025-01-09T15:18:16.907951Z"
-    }
+    },
+    "id": "1ec0a420-d284-4577-8d55-8b11831f997d"
    },
    "outputs": [
     {
@@ -518,22 +570,149 @@
      ]
     }
    ],
-   "execution_count": 35
+   "source": [
+    "import json\n",
+    "import time\n",
+    "\n",
+    "while True:\n",
+    "    job_details = extraction.get_job_details(job_id)\n",
+    "    status = job_details['entity']['results']['status']\n",
+    "\n",
+    "    if status == \"completed\":\n",
+    "        print(\"Job completed successfully, details: {}\".format(json.dumps(job_details, indent=2)))\n",
+    "        break\n",
+    "\n",
+    "    if status == \"failed\":\n",
+    "        print(\"Job failed, details: {}. \\n Try to run job again.\".format(json.dumps(job_details, indent=2)))\n",
+    "        break\n",
+    "\n",
+    "    time.sleep(10)"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Get the text extraction result.",
-   "id": "7635ca019a2ace22"
+   "id": "7635ca019a2ace22",
+   "metadata": {},
+   "source": [
+    "Get the text extraction result."
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "15359c4bd8c91558",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:18:49.269284Z",
      "start_time": "2025-01-09T15:18:48.566344Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "†Corresponding Authors \n",
+       "\n",
+       "Large Language Models (LLMs) trained on code are revolutionizing the software development process. Increasingly, code LLMs are being inte- grated into software development environments to improve the produc- tivity of human programmers, and LLM-based agents are beginning to show promise for handling complex tasks autonomously. Realizing the full potential of code LLMs requires a wide range of capabilities, including code generation, fixing bugs, explaining and documenting code, maintaining repositories, and more. In this work, we introduce the Granite series of decoder-only code models for code generative tasks, trained with code written in 116 programming languages. The Granite Code models family consists of models ranging in size from 3 to 34 billion parameters, suitable for applications ranging from complex application modernization tasks to on-device memory-constrained use cases. Evaluation on a comprehensive set of tasks demonstrates that Granite Code models consistently reaches state-of-the-art performance among available open-source code LLMs. The Granite Code model family was optimized for enterprise software devel- opment workflows and performs well across a range of coding tasks (e.g. code generation, fixing and explanation), making it a versatile “all around” code model. We release all our Granite Code models under an Apache 2.0 license for both research and commercial use. https://github.com/ibm-granite/granite-code-models \n",
+       "\n",
+       "# 1 Introduction \n",
+       "\n",
+       "Over the last several decades, software has been woven into the fabric of every aspect of our society. As demand for software development surges, it is more critical than ever to increase software development productivity, and LLMs provide promising path for augmenting human programmers. Prominent enterprise use cases for LLMs in software development productivity include code generation, code explanation, code fixing, unit test and documentation generation, application modernization, vulnerability detection, code translation, and more. \n",
+       "\n",
+       "Recent years have seen rapid progress in LLM’s ability to generate and manipulate code, and a range of models with impressive coding abilities are available today. Models range in 43.5 \n",
+       "\n",
+       "* 41.5\n",
+       "\n",
+       "\t+ 37.4\n",
+       "\t+ 34.4\n",
+       "\t+ 31.2\n",
+       "\t+ 29.2\n",
+       "\t\n",
+       "\t\t- 29.0\n",
+       "\t\t\n",
+       "\t\t\t* 33.2\n",
+       "\t\t\t* 18.9\n",
+       "\t\t\t\n",
+       "\t\t\t\t+ 19.\n",
+       "\t\t\t\t\n",
+       "\t\t\t\t\t- 21.3\n",
+       "\t\t\t\t\t- 15.1 \n",
+       "\t\t\t\t\t\t* 15.0\n",
+       "\t\t\t\t\t- 29.6\n",
+       "\t\t\t\t\t- 26.\n",
+       "\t\t\t\t\t- 14.2\n",
+       "\t\t\t\t\tO.\n",
+       "\t\t\t\t\t- 7.\n",
+       "\t\t\t\t\t\n",
+       "\t\t\t\t\t\t* 8.9\n",
+       "\t\t\t\t\t\t* 2.9\n",
+       "\t\t\t\t+ 20.\n",
+       "\t+ 15.0\n",
+       "\t+ 13.4\n",
+       "\t+ 13.5\n",
+       "\t+ 13.9\n",
+       "\t+ 12.4Generating Code \n",
+       "\n",
+       "Explaining Code \n",
+       "\n",
+       "Fixing Code \n",
+       "\n",
+       "Average \n",
+       "\n",
+       "O MistralAI/Mistral-7B W @ Meta/Llama-3-8B \n",
+       "\n",
+       "@) Google/Gemma-7B \n",
+       "\n",
+       "Meta/CodeLlama-7B @) Google/CodeGemma-7B @ IBM/Granite-8B-Code-Base W \n",
+       "\n",
+       "@ BigCode/StarCoder2-7B \n",
+       "\n",
+       "Apache 2.0 License \n",
+       "\n",
+       "\n",
+       "\t+ 49.6\n",
+       "* 41.6\n",
+       "* 36.9\n",
+       "* 37.9\n",
+       "* 19.8\n",
+       "* 40.9\n",
+       "* 38.4\n",
+       "\n",
+       "29.1 | \n",
+       "\n",
+       "* 25.1\n",
+       "\n",
+       "21 \n",
+       "\n",
+       "* 41.9\n",
+       "* 43.6\n",
+       "* 5.8\n",
+       "* 31.8\n",
+       "* 25.3\n",
+       "* 18.3\n",
+       "* 13.7\n",
+       "* 112.8\n",
+       "\n",
+       "Generating Code \n",
+       "\n",
+       "Explaining Code \n",
+       "\n",
+       "Fixing Code \n",
+       "\n",
+       "Average \n",
+       "\n",
+       "O MistralAI/Mistral-7B-Instruct-v0.2 \n",
+       "\n",
+       "@ Meta/CodeLlama-7B-Instru"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from IPython.display import display, Markdown\n",
     "\n",
@@ -546,44 +725,39 @@
     "with open(te_result_filename, 'r', encoding='utf-8') as file:\n",
     "    # Display beginning of the result file\n",
     "    display(Markdown((file.read()[:3000])))"
-   ],
-   "id": "15359c4bd8c91558",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ],
-      "text/markdown": "†Corresponding Authors \n\nLarge Language Models (LLMs) trained on code are revolutionizing the software development process. Increasingly, code LLMs are being inte- grated into software development environments to improve the produc- tivity of human programmers, and LLM-based agents are beginning to show promise for handling complex tasks autonomously. Realizing the full potential of code LLMs requires a wide range of capabilities, including code generation, fixing bugs, explaining and documenting code, maintaining repositories, and more. In this work, we introduce the Granite series of decoder-only code models for code generative tasks, trained with code written in 116 programming languages. The Granite Code models family consists of models ranging in size from 3 to 34 billion parameters, suitable for applications ranging from complex application modernization tasks to on-device memory-constrained use cases. Evaluation on a comprehensive set of tasks demonstrates that Granite Code models consistently reaches state-of-the-art performance among available open-source code LLMs. The Granite Code model family was optimized for enterprise software devel- opment workflows and performs well across a range of coding tasks (e.g. code generation, fixing and explanation), making it a versatile “all around” code model. We release all our Granite Code models under an Apache 2.0 license for both research and commercial use. https://github.com/ibm-granite/granite-code-models \n\n# 1 Introduction \n\nOver the last several decades, software has been woven into the fabric of every aspect of our society. As demand for software development surges, it is more critical than ever to increase software development productivity, and LLMs provide promising path for augmenting human programmers. Prominent enterprise use cases for LLMs in software development productivity include code generation, code explanation, code fixing, unit test and documentation generation, application modernization, vulnerability detection, code translation, and more. \n\nRecent years have seen rapid progress in LLM’s ability to generate and manipulate code, and a range of models with impressive coding abilities are available today. Models range in 43.5 \n\n* 41.5\n\n\t+ 37.4\n\t+ 34.4\n\t+ 31.2\n\t+ 29.2\n\t\n\t\t- 29.0\n\t\t\n\t\t\t* 33.2\n\t\t\t* 18.9\n\t\t\t\n\t\t\t\t+ 19.\n\t\t\t\t\n\t\t\t\t\t- 21.3\n\t\t\t\t\t- 15.1 \n\t\t\t\t\t\t* 15.0\n\t\t\t\t\t- 29.6\n\t\t\t\t\t- 26.\n\t\t\t\t\t- 14.2\n\t\t\t\t\tO.\n\t\t\t\t\t- 7.\n\t\t\t\t\t\n\t\t\t\t\t\t* 8.9\n\t\t\t\t\t\t* 2.9\n\t\t\t\t+ 20.\n\t+ 15.0\n\t+ 13.4\n\t+ 13.5\n\t+ 13.9\n\t+ 12.4Generating Code \n\nExplaining Code \n\nFixing Code \n\nAverage \n\nO MistralAI/Mistral-7B W @ Meta/Llama-3-8B \n\n@) Google/Gemma-7B \n\nMeta/CodeLlama-7B @) Google/CodeGemma-7B @ IBM/Granite-8B-Code-Base W \n\n@ BigCode/StarCoder2-7B \n\nApache 2.0 License \n\n\n\t+ 49.6\n* 41.6\n* 36.9\n* 37.9\n* 19.8\n* 40.9\n* 38.4\n\n29.1 | \n\n* 25.1\n\n21 \n\n* 41.9\n* 43.6\n* 5.8\n* 31.8\n* 25.3\n* 18.3\n* 13.7\n* 112.8\n\nGenerating Code \n\nExplaining Code \n\nFixing Code \n\nAverage \n\nO MistralAI/Mistral-7B-Instruct-v0.2 \n\n@ Meta/CodeLlama-7B-Instru"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "execution_count": 36
+   ]
   },
   {
-   "id": "ce5b2ba9ba5f967",
    "cell_type": "markdown",
+   "id": "ce5b2ba9ba5f967",
+   "metadata": {},
    "source": [
     "<a id=\"prepare-autorag\"></a>\n",
     "## Prepare data and connections for the AutoAI RAG experiment"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "63872845c85d401d",
    "cell_type": "markdown",
+   "id": "63872845c85d401d",
+   "metadata": {},
    "source": [
     "Upload a `json` file to use for benchmarking to COS and define a connection to this file. \n",
     "\n",
     "Note: `correct_answer_document_ids` must refer to the document processed by text extraction service, not the initial document."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "7491bef8c96b7040",
    "cell_type": "code",
+   "execution_count": 37,
+   "id": "7491bef8c96b7040",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-09T15:20:47.702283Z",
+     "start_time": "2025-01-09T15:20:47.699273Z"
+    },
+    "id": "e399f617-9515-48d7-a38c-e66c8116dc34"
+   },
+   "outputs": [],
    "source": [
     "benchmarking_data = [\n",
     "     {\n",
@@ -602,20 +776,20 @@
     "        \"correct_answer_document_ids\": [te_result_filename]\n",
     "     },\n",
     "]"
-   ],
-   "metadata": {
-    "id": "e399f617-9515-48d7-a38c-e66c8116dc34",
-    "ExecuteTime": {
-     "end_time": "2025-01-09T15:20:47.702283Z",
-     "start_time": "2025-01-09T15:20:47.699273Z"
-    }
-   },
-   "outputs": [],
-   "execution_count": 37
+   ]
   },
   {
-   "id": "c0e92e1d32467d6f",
    "cell_type": "code",
+   "execution_count": 38,
+   "id": "c0e92e1d32467d6f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-01-09T15:20:48.687662Z",
+     "start_time": "2025-01-09T15:20:48.178141Z"
+    },
+    "id": "008a8db8-b1d2-42f8-9f25-1861d1ea4771"
+   },
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
@@ -626,60 +800,66 @@
     "        json.dump(benchmarking_data, json_file, indent=4)\n",
     "\n",
     "cos_client.upload_file(test_filename, cos_bucket_name, test_filename)"
-   ],
-   "metadata": {
-    "id": "008a8db8-b1d2-42f8-9f25-1861d1ea4771",
-    "ExecuteTime": {
-     "end_time": "2025-01-09T15:20:48.687662Z",
-     "start_time": "2025-01-09T15:20:48.178141Z"
-    }
-   },
-   "outputs": [],
-   "execution_count": 38
+   ]
   },
   {
-   "id": "1a15c37edb8aa736",
    "cell_type": "markdown",
-   "source": "Test the data connection.",
-   "metadata": {}
+   "id": "1a15c37edb8aa736",
+   "metadata": {},
+   "source": [
+    "Test the data connection."
+   ]
   },
   {
-   "id": "a5fd521450aa575d",
    "cell_type": "code",
-   "source": "test_data_reference = DataConnection(\n    connection_asset_id=cos_connection_id,\n    location=S3Location(bucket=cos_bucket_name, path=test_filename),\n)\ntest_data_reference.set_client(client)\n\ntest_data_references = [test_data_reference]",
+   "execution_count": 39,
+   "id": "a5fd521450aa575d",
    "metadata": {
-    "id": "49237e6c-aa57-459a-a9b8-99bc00c29573",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:20:50.372300Z",
      "start_time": "2025-01-09T15:20:50.369900Z"
-    }
+    },
+    "id": "49237e6c-aa57-459a-a9b8-99bc00c29573"
    },
    "outputs": [],
-   "execution_count": 39
+   "source": [
+    "test_data_reference = DataConnection(\n",
+    "    connection_asset_id=cos_connection_id,\n",
+    "    location=S3Location(bucket=cos_bucket_name, path=test_filename),\n",
+    ")\n",
+    "test_data_reference.set_client(client)\n",
+    "\n",
+    "test_data_references = [test_data_reference]"
+   ]
   },
   {
-   "id": "bcc6c6b167fe11fd",
    "cell_type": "markdown",
-   "source": "Use the reference to the Text Extraction job result as input for the AutoAI RAG experiment.",
-   "metadata": {}
+   "id": "bcc6c6b167fe11fd",
+   "metadata": {},
+   "source": [
+    "Use the reference to the Text Extraction job result as input for the AutoAI RAG experiment."
+   ]
   },
   {
-   "id": "4451ab741f192d94",
    "cell_type": "code",
-   "source": "input_data_references = [result_data_reference]",
+   "execution_count": 40,
+   "id": "4451ab741f192d94",
    "metadata": {
-    "id": "eb86615c-5d19-46e1-8179-9af89eaf0d58",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:20:51.336293Z",
      "start_time": "2025-01-09T15:20:51.334349Z"
-    }
+    },
+    "id": "eb86615c-5d19-46e1-8179-9af89eaf0d58"
    },
    "outputs": [],
-   "execution_count": 40
+   "source": [
+    "input_data_references = [result_data_reference]"
+   ]
   },
   {
-   "id": "5af97452ce3a4da6",
    "cell_type": "markdown",
+   "id": "5af97452ce3a4da6",
+   "metadata": {},
    "source": [
     "<a id=\"run-autorag\"></a>\n",
     "# Run the AutoAI RAG experiment\n",
@@ -689,50 +869,54 @@
     "- `description` - experiment description\n",
     "- `max_number_of_rag_patterns` - maximum number of RAG patterns to create\n",
     "- `optimization_metrics` - target optimization metrics"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "619457e9a66bcc24",
    "cell_type": "code",
-   "source": "from ibm_watsonx_ai.experiment import AutoAI\n\nexperiment = AutoAI(credentials, space_id=SPACE_ID)\n\nrag_optimizer = experiment.rag_optimizer(\n    name='AutoAI RAG - Text Extraction service experiment',\n    description = \"AutoAI RAG experiment on documents generated by text extraction service\",\n    max_number_of_rag_patterns=5,\n    optimization_metrics=['answer_correctness']\n) ",
+   "execution_count": 41,
+   "id": "619457e9a66bcc24",
    "metadata": {
-    "id": "089a0f87-c462-4873-9e86-e2f44e5f5ffd",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:20:55.393763Z",
      "start_time": "2025-01-09T15:20:53.462724Z"
-    }
+    },
+    "id": "089a0f87-c462-4873-9e86-e2f44e5f5ffd"
    },
    "outputs": [],
-   "execution_count": 41
+   "source": [
+    "from ibm_watsonx_ai.experiment import AutoAI\n",
+    "\n",
+    "experiment = AutoAI(credentials, space_id=SPACE_ID)\n",
+    "\n",
+    "rag_optimizer = experiment.rag_optimizer(\n",
+    "    name='AutoAI RAG - Text Extraction service experiment',\n",
+    "    description = \"AutoAI RAG experiment on documents generated by text extraction service\",\n",
+    "    max_number_of_rag_patterns=5,\n",
+    "    optimization_metrics=['answer_correctness']\n",
+    ")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "eebec0a74b713ef7",
+   "metadata": {},
    "source": [
     "Call the `run()` method to trigger the AutoAI RAG experiment. Choose one of two modes: \n",
     "\n",
     "- To use the **interactive mode** (synchronous job), specify `background_mode=False` \n",
     "- To use the **background mode** (asynchronous job), specify `background_mode=True`"
-   ],
-   "id": "eebec0a74b713ef7"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "aa3fc7d25f0cf32f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:42:37.566687Z",
      "start_time": "2025-01-09T15:39:11.085027Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "rag_optimizer.run(\n",
-    "    input_data_references=input_data_references,\n",
-    "    test_data_references=test_data_references,\n",
-    "    background_mode=False\n",
-    ");"
-   ],
-   "id": "aa3fc7d25f0cf32f",
    "outputs": [
     {
      "name": "stdout",
@@ -754,76 +938,38 @@
      ]
     }
    ],
-   "execution_count": 51
+   "source": [
+    "rag_optimizer.run(\n",
+    "    input_data_references=input_data_references,\n",
+    "    test_data_references=test_data_references,\n",
+    "    background_mode=False\n",
+    ");"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "4563ecfaed85b633",
+   "metadata": {},
    "source": [
     "<a id=\"comparison\"></a>\n",
     "## Compare and test of RAG Patterns\n",
     "\n",
     "You can list the trained patterns and information on evaluation metrics in the form of a Pandas DataFrame by calling the `summary()` method. You can use the DataFrame to compare all discovered patterns and select the one you like for further testing."
-   ],
-   "id": "4563ecfaed85b633"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "dc2a28877f1459e6",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:43:10.039483Z",
      "start_time": "2025-01-09T15:43:10.032861Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "summary = rag_optimizer.summary()\n",
-    "summary"
-   ],
-   "id": "dc2a28877f1459e6",
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "              mean_answer_correctness  mean_faithfulness  \\\n",
-       "Pattern_Name                                               \n",
-       "Pattern2                       0.7813             0.7882   \n",
-       "Pattern4                       0.7566             0.8904   \n",
-       "Pattern1                       0.7207             0.7074   \n",
-       "Pattern5                       0.7196             0.9690   \n",
-       "Pattern3                       0.6731             0.5211   \n",
-       "\n",
-       "              mean_context_correctness  chunking.chunk_size  \\\n",
-       "Pattern_Name                                                  \n",
-       "Pattern2                           1.0                 1024   \n",
-       "Pattern4                           1.0                 1024   \n",
-       "Pattern1                           1.0                  512   \n",
-       "Pattern5                           1.0                 1024   \n",
-       "Pattern3                           1.0                 1024   \n",
-       "\n",
-       "                         embeddings.model_id vector_store.distance_metric  \\\n",
-       "Pattern_Name                                                                \n",
-       "Pattern2      intfloat/multilingual-e5-large                    euclidean   \n",
-       "Pattern4      intfloat/multilingual-e5-large                       cosine   \n",
-       "Pattern1        ibm/slate-125m-english-rtrvr                    euclidean   \n",
-       "Pattern5      intfloat/multilingual-e5-large                       cosine   \n",
-       "Pattern3      intfloat/multilingual-e5-large                    euclidean   \n",
-       "\n",
-       "             retrieval.method  retrieval.number_of_chunks  \\\n",
-       "Pattern_Name                                                \n",
-       "Pattern2               window                           5   \n",
-       "Pattern4               window                           5   \n",
-       "Pattern1               window                           5   \n",
-       "Pattern5               window                           3   \n",
-       "Pattern3               simple                           5   \n",
-       "\n",
-       "                              generation.model_id  \n",
-       "Pattern_Name                                       \n",
-       "Pattern2          meta-llama/llama-3-70b-instruct  \n",
-       "Pattern4      mistralai/mixtral-8x7b-instruct-v01  \n",
-       "Pattern1      mistralai/mixtral-8x7b-instruct-v01  \n",
-       "Pattern5                  ibm/granite-13b-chat-v2  \n",
-       "Pattern3          meta-llama/llama-3-70b-instruct  "
-      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -930,6 +1076,47 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
+      ],
+      "text/plain": [
+       "              mean_answer_correctness  mean_faithfulness  \\\n",
+       "Pattern_Name                                               \n",
+       "Pattern2                       0.7813             0.7882   \n",
+       "Pattern4                       0.7566             0.8904   \n",
+       "Pattern1                       0.7207             0.7074   \n",
+       "Pattern5                       0.7196             0.9690   \n",
+       "Pattern3                       0.6731             0.5211   \n",
+       "\n",
+       "              mean_context_correctness  chunking.chunk_size  \\\n",
+       "Pattern_Name                                                  \n",
+       "Pattern2                           1.0                 1024   \n",
+       "Pattern4                           1.0                 1024   \n",
+       "Pattern1                           1.0                  512   \n",
+       "Pattern5                           1.0                 1024   \n",
+       "Pattern3                           1.0                 1024   \n",
+       "\n",
+       "                         embeddings.model_id vector_store.distance_metric  \\\n",
+       "Pattern_Name                                                                \n",
+       "Pattern2      intfloat/multilingual-e5-large                    euclidean   \n",
+       "Pattern4      intfloat/multilingual-e5-large                       cosine   \n",
+       "Pattern1        ibm/slate-125m-english-rtrvr                    euclidean   \n",
+       "Pattern5      intfloat/multilingual-e5-large                       cosine   \n",
+       "Pattern3      intfloat/multilingual-e5-large                    euclidean   \n",
+       "\n",
+       "             retrieval.method  retrieval.number_of_chunks  \\\n",
+       "Pattern_Name                                                \n",
+       "Pattern2               window                           5   \n",
+       "Pattern4               window                           5   \n",
+       "Pattern1               window                           5   \n",
+       "Pattern5               window                           3   \n",
+       "Pattern3               simple                           5   \n",
+       "\n",
+       "                              generation.model_id  \n",
+       "Pattern_Name                                       \n",
+       "Pattern2          meta-llama/llama-3-70b-instruct  \n",
+       "Pattern4      mistralai/mixtral-8x7b-instruct-v01  \n",
+       "Pattern1      mistralai/mixtral-8x7b-instruct-v01  \n",
+       "Pattern5                  ibm/granite-13b-chat-v2  \n",
+       "Pattern3          meta-llama/llama-3-70b-instruct  "
       ]
      },
      "execution_count": 52,
@@ -937,33 +1124,31 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 52
+   "source": [
+    "summary = rag_optimizer.summary()\n",
+    "summary"
+   ]
   },
   {
-   "id": "dd2f1b669bfa61df",
    "cell_type": "markdown",
+   "id": "dd2f1b669bfa61df",
+   "metadata": {},
    "source": [
     "### Get the selected pattern\n",
     "\n",
     "Get the RAGPattern object from the RAG Optimizer experiment. By default, the RAGPattern of the best pattern is returned."
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "e423064a26b8f02e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:43:21.184717Z",
      "start_time": "2025-01-09T15:43:16.112583Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "best_pattern_name = summary.index.values[0]\n",
-    "print('Best pattern is:', best_pattern_name)\n",
-    "\n",
-    "best_pattern = rag_optimizer.get_pattern()"
-   ],
-   "id": "e423064a26b8f02e",
    "outputs": [
     {
      "name": "stdout",
@@ -973,18 +1158,23 @@
      ]
     }
    ],
-   "execution_count": 55
+   "source": [
+    "best_pattern_name = summary.index.values[0]\n",
+    "print('Best pattern is:', best_pattern_name)\n",
+    "\n",
+    "best_pattern = rag_optimizer.get_pattern()"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "4cb7325de0524ebc",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-01-09T15:43:23.819629Z",
      "start_time": "2025-01-09T15:43:23.816088Z"
     }
    },
-   "cell_type": "code",
-   "source": "rag_optimizer.get_pattern_details(pattern_name=best_pattern_name)",
-   "id": "4cb7325de0524ebc",
    "outputs": [
     {
      "data": {
@@ -1046,38 +1236,55 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 56
+   "source": [
+    "rag_optimizer.get_pattern_details(pattern_name=best_pattern_name)"
+   ]
   },
   {
-   "id": "3717292bbd09cd99",
    "cell_type": "markdown",
-   "source": "Test the RAGPattern by querying it locally.",
-   "metadata": {}
+   "id": "3717292bbd09cd99",
+   "metadata": {},
+   "source": [
+    "Test the RAGPattern by querying it locally."
+   ]
   },
   {
-   "id": "592456e149f2e372",
    "cell_type": "code",
-   "source": "questions = [\"Which industry players are mentioned as IBM’s strategic partners?\"]\n\npayload = {\n    client.deployments.ScoringMetaNames.INPUT_DATA: [\n        {\n            \"values\": questions,\n            \"access_token\": client.service_instance._get_token()\n        }\n    ]\n}\n\nresp = best_pattern.inference_function()(payload)",
+   "execution_count": 57,
+   "id": "592456e149f2e372",
    "metadata": {
-    "id": "55347731-5421-4c10-ae4c-fe64d0ebd0ed",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:43:33.270994Z",
      "start_time": "2025-01-09T15:43:26.474640Z"
-    }
+    },
+    "id": "55347731-5421-4c10-ae4c-fe64d0ebd0ed"
    },
    "outputs": [],
-   "execution_count": 57
+   "source": [
+    "questions = [\"Which industry players are mentioned as IBM’s strategic partners?\"]\n",
+    "\n",
+    "payload = {\n",
+    "    client.deployments.ScoringMetaNames.INPUT_DATA: [\n",
+    "        {\n",
+    "            \"values\": questions,\n",
+    "            \"access_token\": client.token\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "resp = best_pattern.inference_function()(payload)"
+   ]
   },
   {
-   "id": "6a9c4abbcb4d316b",
    "cell_type": "code",
-   "source": "print(resp[\"predictions\"][0][\"values\"][0][0])",
+   "execution_count": 58,
+   "id": "6a9c4abbcb4d316b",
    "metadata": {
-    "id": "34477967-8812-41bd-93ee-b967261bcef3",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:43:33.278401Z",
      "start_time": "2025-01-09T15:43:33.276771Z"
-    }
+    },
+    "id": "34477967-8812-41bd-93ee-b967261bcef3"
    },
    "outputs": [
     {
@@ -1097,28 +1304,30 @@
      ]
     }
    ],
-   "execution_count": 58
+   "source": [
+    "print(resp[\"predictions\"][0][\"values\"][0][0])"
+   ]
   },
   {
-   "id": "6f2d80de4b2b1d60",
    "cell_type": "markdown",
+   "id": "6f2d80de4b2b1d60",
+   "metadata": {},
    "source": [
     "### Deploy the RAGPattern\n",
     "\n",
     "Store the defined RAG function and create a deployed asset to deploy the RAGPattern."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "85769eb45d41892f",
    "cell_type": "code",
-   "source": "deployment_details = best_pattern.deploy(\n    name=\"AutoAI RAG deployment - ibm_watsonx_ai documentataion\",\n    space_id=SPACE_ID\n)",
+   "execution_count": 59,
+   "id": "85769eb45d41892f",
    "metadata": {
-    "id": "6e9565b6-9937-4adb-b0a0-865293fa9d3a",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:44:02.586747Z",
      "start_time": "2025-01-09T15:43:33.300291Z"
-    }
+    },
+    "id": "6e9565b6-9937-4adb-b0a0-865293fa9d3a"
    },
    "outputs": [
     {
@@ -1148,28 +1357,33 @@
      ]
     }
    ],
-   "execution_count": 59
+   "source": [
+    "deployment_details = best_pattern.deploy(\n",
+    "    name=\"AutoAI RAG deployment - ibm_watsonx_ai documentataion\",\n",
+    "    space_id=SPACE_ID\n",
+    ")"
+   ]
   },
   {
-   "id": "1ba0e83cfdbf9fa8",
    "cell_type": "markdown",
+   "id": "1ba0e83cfdbf9fa8",
+   "metadata": {},
    "source": [
     "### Test the deployed function\n",
     "\n",
     "The RAG service is now deployed in the space. To test the solution, run the cell below. Questions have to be provided in the payload. Their format is provided below."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "ddf657bac40a25f0",
    "cell_type": "code",
-   "source": "deployment_id = client.deployments.get_id(deployment_details)\n\nscore_response = client.deployments.score(deployment_id, payload)\nscore_response",
+   "execution_count": 60,
+   "id": "ddf657bac40a25f0",
    "metadata": {
-    "id": "79f5e89f-d5a7-4454-98fd-45325b366dfd",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:44:08.959582Z",
      "start_time": "2025-01-09T15:44:02.594917Z"
-    }
+    },
+    "id": "79f5e89f-d5a7-4454-98fd-45325b366dfd"
    },
    "outputs": [
     {
@@ -1185,18 +1399,23 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 60
+   "source": [
+    "deployment_id = client.deployments.get_id(deployment_details)\n",
+    "\n",
+    "score_response = client.deployments.score(deployment_id, payload)\n",
+    "score_response"
+   ]
   },
   {
-   "id": "db6e9ab2b9cd65d8",
    "cell_type": "code",
-   "source": "print(score_response[\"predictions\"][0][\"values\"][0][0])",
+   "execution_count": 61,
+   "id": "db6e9ab2b9cd65d8",
    "metadata": {
-    "id": "0157dc60-b62d-4839-86fc-007c838ce66f",
     "ExecuteTime": {
      "end_time": "2025-01-09T15:44:08.972331Z",
      "start_time": "2025-01-09T15:44:08.970146Z"
-    }
+    },
+    "id": "0157dc60-b62d-4839-86fc-007c838ce66f"
    },
    "outputs": [
     {
@@ -1216,11 +1435,14 @@
      ]
     }
    ],
-   "execution_count": 61
+   "source": [
+    "print(score_response[\"predictions\"][0][\"values\"][0][0])"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "f7bfe92044e177db",
+   "metadata": {},
    "source": [
     "<a id=\"summary\"></a>\n",
     "## Summary\n",
@@ -1230,23 +1452,45 @@
     " You learned how to use AutoAI RAG with documents processed by the TextExtraction service.\n",
     " \n",
     "Check out our _<a href=\"https://ibm.github.io/watson-machine-learning-sdk/samples.html\" target=\"_blank\" rel=\"noopener no referrer\">Online Documentation</a>_ for more samples, tutorials, documentation, how-tos, and blog posts. "
-   ],
-   "id": "f7bfe92044e177db"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "3fc6379584dc38f4",
+   "metadata": {},
    "source": [
     "### Author:\n",
     " **Witold Nowogórski**, Software Engineer at watsonx.ai."
-   ],
-   "id": "3fc6379584dc38f4"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Copyright © 2025 IBM. This notebook and its source code are released under the terms of the MIT License.",
-   "id": "8cc73dddba1afbbd"
+   "id": "8cc73dddba1afbbd",
+   "metadata": {},
+   "source": [
+    "Copyright © 2025 IBM. This notebook and its source code are released under the terms of the MIT License."
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Chroma to create a pattern about IBM.html
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Chroma to create a pattern about IBM.html
@@ -7585,7 +7585,7 @@ a.anchor-link {
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.1.11'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.2.4'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 <span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s2">"langchain_community&gt;=0.3,&lt;0.4"</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 </pre></div>
 </div>
@@ -7931,7 +7931,7 @@ SUCCESS
     <span class="n">retrieval_methods</span><span class="o">=</span><span class="p">[</span><span class="s2">"simple"</span><span class="p">],</span>
     <span class="n">chunking</span><span class="o">=</span><span class="p">[</span>
         <span class="p">{</span>
-            <span class="s2">"chunk_size"</span><span class="p">:</span> <span class="mi">512</span><span class="p">,</span> 
+            <span class="s2">"chunk_size"</span><span class="p">:</span> <span class="mi">512</span><span class="p">,</span>
             <span class="s2">"chunk_overlap"</span><span class="p">:</span> <span class="mi">64</span><span class="p">,</span>
             <span class="s2">"method"</span><span class="p">:</span> <span class="s2">"recursive"</span>
         <span class="p">}</span>
@@ -8764,7 +8764,7 @@ Training of 'efb6f9ce-8057-4fc1-9d84-5d2d78ffcf69' finished successfully.
     <span class="n">client</span><span class="o">.</span><span class="n">deployments</span><span class="o">.</span><span class="n">ScoringMetaNames</span><span class="o">.</span><span class="n">INPUT_DATA</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
             <span class="s2">"values"</span><span class="p">:</span> <span class="n">questions</span><span class="p">,</span>
-            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">service_instance</span><span class="o">.</span><span class="n">_get_token</span><span class="p">()</span>
+            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">token</span>
         <span class="p">}</span>
     <span class="p">]</span>
 <span class="p">}</span>

--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Milvus to create a pattern about IBM.html
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Milvus to create a pattern about IBM.html
@@ -7586,7 +7586,7 @@ a.anchor-link {
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="n">wget</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
-<span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.1.11'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
+<span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.2.4'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 </pre></div>
 </div>
 </div>
@@ -7722,7 +7722,7 @@ a.anchor-link {
 <span class="n">filename</span> <span class="o">=</span> <span class="s2">"watsonx-ai-python-sdk"</span>
 <span class="n">filename_zip</span> <span class="o">=</span> <span class="s2">"watsonx-ai-python-sdk.zip"</span>
 
-<span class="k">if</span> <span class="ow">not</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">isfile</span><span class="p">(</span><span class="n">filename_zip</span><span class="p">):</span> 
+<span class="k">if</span> <span class="ow">not</span> <span class="n">os</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">isfile</span><span class="p">(</span><span class="n">filename_zip</span><span class="p">):</span>
     <span class="n">wget</span><span class="o">.</span><span class="n">download</span><span class="p">(</span><span class="s2">"https://github.com/IBM/watsonx-ai-python-sdk/archive/refs/heads/gh-pages.zip"</span><span class="p">,</span> <span class="n">out</span><span class="o">=</span><span class="n">filename_zip</span><span class="p">)</span>
 
 <span class="k">with</span> <span class="n">zipfile</span><span class="o">.</span><span class="n">ZipFile</span><span class="p">(</span><span class="n">filename_zip</span><span class="p">,</span> <span class="s2">"r"</span><span class="p">)</span> <span class="k">as</span> <span class="n">zip_ref</span><span class="p">:</span>
@@ -7805,7 +7805,7 @@ a.anchor-link {
 
 <span class="k">for</span> <span class="n">ind</span><span class="p">,</span> <span class="n">html_docs_file</span> <span class="ow">in</span> <span class="nb">enumerate</span><span class="p">(</span><span class="n">html_docs_files</span><span class="p">):</span>
     <span class="n">container_data_connection</span><span class="o">.</span><span class="n">write</span><span class="p">(</span><span class="n">html_docs_file</span><span class="p">,</span> <span class="n">remote_name</span> <span class="o">=</span> <span class="n">html_docs_file</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s2">"/"</span><span class="p">)[</span><span class="o">-</span><span class="mi">1</span><span class="p">])</span>
-    
+
     <span class="n">sys</span><span class="o">.</span><span class="n">stdout</span><span class="o">.</span><span class="n">write</span><span class="p">(</span><span class="sa">f</span><span class="s2">"</span><span class="se">\r</span><span class="s2">Progress: </span><span class="si">{</span><span class="s1">'✓'</span><span class="w"> </span><span class="o">*</span><span class="w"> </span><span class="p">(</span><span class="n">ind</span><span class="o">+</span><span class="mi">1</span><span class="p">)</span><span class="si">}{</span><span class="s1">'.'</span><span class="w"> </span><span class="o">*</span><span class="w"> </span><span class="p">(</span><span class="nb">len</span><span class="p">(</span><span class="n">html_docs_files</span><span class="p">)</span><span class="o">-</span><span class="n">ind</span><span class="o">-</span><span class="mi">1</span><span class="p">)</span><span class="si">}</span><span class="se">\r</span><span class="s2">"</span><span class="p">)</span>
     <span class="n">sys</span><span class="o">.</span><span class="n">stdout</span><span class="o">.</span><span class="n">flush</span><span class="p">()</span>
 </pre></div>
@@ -8614,7 +8614,7 @@ Training of '40770d34-62d4-4135-b828-ac58d763cea0' finished successfully.
     <span class="n">client</span><span class="o">.</span><span class="n">deployments</span><span class="o">.</span><span class="n">ScoringMetaNames</span><span class="o">.</span><span class="n">INPUT_DATA</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
             <span class="s2">"values"</span><span class="p">:</span> <span class="n">questions</span><span class="p">,</span>
-            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">service_instance</span><span class="o">.</span><span class="n">_get_token</span><span class="p">()</span>
+            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">token</span>
         <span class="p">}</span>
     <span class="p">]</span>
 <span class="p">}</span>

--- a/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG with watsonx Text Extraction service.html
+++ b/cloud/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG with watsonx Text Extraction service.html
@@ -7587,7 +7587,7 @@ The data used in this notebook is from the <a href="https://arxiv.org/pdf/2405.0
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.1.24'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.2.4'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 <span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s2">"langchain_community&gt;=0.3,&lt;0.4"</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 </pre></div>
 </div>
@@ -7940,7 +7940,7 @@ SUCCESS
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="n">result_data_reference</span> <span class="o">=</span> <span class="n">DataConnection</span><span class="p">(</span>
-    <span class="n">connection_asset_id</span><span class="o">=</span><span class="n">cos_connection_id</span><span class="p">,</span> 
+    <span class="n">connection_asset_id</span><span class="o">=</span><span class="n">cos_connection_id</span><span class="p">,</span>
     <span class="n">location</span><span class="o">=</span><span class="n">S3Location</span><span class="p">(</span>
         <span class="n">bucket</span><span class="o">=</span><span class="n">cos_bucket_name</span><span class="p">,</span>
         <span class="n">path</span><span class="o">=</span><span class="n">te_result_filename</span>
@@ -8059,11 +8059,11 @@ SUCCESS
 <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
     <span class="n">job_details</span> <span class="o">=</span> <span class="n">extraction</span><span class="o">.</span><span class="n">get_job_details</span><span class="p">(</span><span class="n">job_id</span><span class="p">)</span>
     <span class="n">status</span> <span class="o">=</span> <span class="n">job_details</span><span class="p">[</span><span class="s1">'entity'</span><span class="p">][</span><span class="s1">'results'</span><span class="p">][</span><span class="s1">'status'</span><span class="p">]</span>
-    
+
     <span class="k">if</span> <span class="n">status</span> <span class="o">==</span> <span class="s2">"completed"</span><span class="p">:</span>
         <span class="nb">print</span><span class="p">(</span><span class="s2">"Job completed successfully, details: </span><span class="si">{}</span><span class="s2">"</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">job_details</span><span class="p">,</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">)))</span>
         <span class="k">break</span>
-    
+
     <span class="k">if</span> <span class="n">status</span> <span class="o">==</span> <span class="s2">"failed"</span><span class="p">:</span>
         <span class="nb">print</span><span class="p">(</span><span class="s2">"Job failed, details: </span><span class="si">{}</span><span class="s2">. </span><span class="se">\n</span><span class="s2"> Try to run job again."</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">job_details</span><span class="p">,</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">)))</span>
         <span class="k">break</span>
@@ -8797,7 +8797,7 @@ Training of 'c8aa6019-c9c5-42da-a082-e2ea741e980e' finished successfully.
     <span class="n">client</span><span class="o">.</span><span class="n">deployments</span><span class="o">.</span><span class="n">ScoringMetaNames</span><span class="o">.</span><span class="n">INPUT_DATA</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
             <span class="s2">"values"</span><span class="p">:</span> <span class="n">questions</span><span class="p">,</span>
-            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">service_instance</span><span class="o">.</span><span class="n">_get_token</span><span class="p">()</span>
+            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">token</span>
         <span class="p">}</span>
     <span class="p">]</span>
 <span class="p">}</span>

--- a/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Chroma to create a pattern about IBM.ipynb
+++ b/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Chroma to create a pattern about IBM.ipynb
@@ -69,7 +69,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install -U 'ibm-watsonx-ai[rag]>=1.1.11' | tail -n 1\n",
+        "!pip install -U 'ibm-watsonx-ai[rag]>=1.2.4' | tail -n 1\n",
         "!pip install -U \"langchain_community>=0.3,<0.4\" | tail -n 1"
       ]
     },
@@ -931,7 +931,7 @@
         "    client.deployments.ScoringMetaNames.INPUT_DATA: [\n",
         "        {\n",
         "            \"values\": questions,\n",
-        "            \"access_token\": client.service_instance._get_token()\n",
+        "            \"access_token\": client.token\n",
         "        }\n",
         "    ]\n",
         "}\n",

--- a/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Milvus to create a pattern about IBM.ipynb
+++ b/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/Use AutoAI RAG and Milvus to create a pattern about IBM.ipynb
@@ -70,7 +70,7 @@
       "outputs": [],
       "source": [
         "!pip install -U wget | tail -n 1\n",
-        "!pip install -U 'ibm-watsonx-ai[rag]>=1.1.11' | tail -n 1"
+        "!pip install -U 'ibm-watsonx-ai[rag]>=1.2.4' | tail -n 1"
       ]
     },
     {
@@ -240,7 +240,7 @@
         "archive_name = \"watsonx-ai-python-sdk\"\n",
         "archive_zip = \"watsonx-ai-python-sdk.zip\"\n",
         "\n",
-        "if not os.path.isfile(archive_zip): \n",
+        "if not os.path.isfile(archive_zip):\n",
         "    wget.download(\"https://github.com/IBM/watsonx-ai-python-sdk/archive/refs/heads/gh-pages.zip\", out=archive_zip)\n",
         "\n",
         "with zipfile.ZipFile(archive_zip, \"r\") as zip_ref:\n",
@@ -364,7 +364,7 @@
         "\n",
         "for ind, html_docs_file in enumerate(html_docs_files):\n",
         "    data_connection.write(html_docs_file, remote_name = html_docs_file.split(\"/\")[-1])\n",
-        "    \n",
+        "\n",
         "    sys.stdout.write(f\"\\rProgress: {'✓' * (ind+1)}{'.' * (len(html_docs_files)-ind-1)}\\r\")\n",
         "    sys.stdout.flush()"
       ]
@@ -993,7 +993,7 @@
         "    client.deployments.ScoringMetaNames.INPUT_DATA: [\n",
         "        {\n",
         "            \"values\": questions,\n",
-        "            \"access_token\": client.service_instance._get_token()\n",
+        "            \"access_token\": client.token\n",
         "        }\n",
         "    ]\n",
         "}\n",

--- a/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Chroma to create a pattern about IBM.html
+++ b/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Chroma to create a pattern about IBM.html
@@ -7585,7 +7585,7 @@ a.anchor-link {
 <div class="jp-InputPrompt jp-InputArea-prompt">In [ ]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
-<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.1.11'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
+<div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.2.4'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 <span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s2">"langchain_community&gt;=0.3,&lt;0.4"</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 </pre></div>
 </div>
@@ -8580,7 +8580,7 @@ Training of '1ee9d070-c83d-4cb5-a435-43d94de1d87f' finished successfully.
     <span class="n">client</span><span class="o">.</span><span class="n">deployments</span><span class="o">.</span><span class="n">ScoringMetaNames</span><span class="o">.</span><span class="n">INPUT_DATA</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
             <span class="s2">"values"</span><span class="p">:</span> <span class="n">questions</span><span class="p">,</span>
-            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">service_instance</span><span class="o">.</span><span class="n">_get_token</span><span class="p">()</span>
+            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">token</span>
         <span class="p">}</span>
     <span class="p">]</span>
 <span class="p">}</span>

--- a/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Milvus to create a pattern about IBM.html
+++ b/cpd5.1/notebooks/python_sdk/experiments/autoai_rag/html/Use AutoAI RAG and Milvus to create a pattern about IBM.html
@@ -7586,7 +7586,7 @@ a.anchor-link {
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
 <div class="cm-editor cm-s-jupyter">
 <div class="highlight hl-ipython3"><pre><span></span><span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="n">wget</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
-<span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.1.11'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
+<span class="err">!</span><span class="n">pip</span> <span class="n">install</span> <span class="o">-</span><span class="n">U</span> <span class="s1">'ibm-watsonx-ai[rag]&gt;=1.2.4'</span> <span class="o">|</span> <span class="n">tail</span> <span class="o">-</span><span class="n">n</span> <span class="mi">1</span>
 </pre></div>
 </div>
 </div>
@@ -8689,7 +8689,7 @@ Training of '38d8ffb0-9d93-4956-9a50-aaef8068e299' finished successfully.
     <span class="n">client</span><span class="o">.</span><span class="n">deployments</span><span class="o">.</span><span class="n">ScoringMetaNames</span><span class="o">.</span><span class="n">INPUT_DATA</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span>
             <span class="s2">"values"</span><span class="p">:</span> <span class="n">questions</span><span class="p">,</span>
-            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">service_instance</span><span class="o">.</span><span class="n">_get_token</span><span class="p">()</span>
+            <span class="s2">"access_token"</span><span class="p">:</span> <span class="n">client</span><span class="o">.</span><span class="n">token</span>
         <span class="p">}</span>
     <span class="p">]</span>
 <span class="p">}</span>


### PR DESCRIPTION
Replaced call to `client.service_instance._get_token()` with `client.token` property.
Since `1.2.4` this is the recommended method of obtaining the token.